### PR TITLE
Added link of Software Architect Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ But please, don’t overdo marketing: In the long term, content is king. If your
 
 
 # Architect's Technology Roadmap
+ * [**Software Architect Roadmap. Complete guide to become a Software Architect**](https://roadmap.sh/software-architect) by Kamran Ahmed.
 ![Architect roadmap](./src/archRoadmap.jpg)
 
 # Types of Solution Architects

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ But please, don’t overdo marketing: In the long term, content is king. If your
 
 # Architect's Technology Roadmap
  * [**Software Architect Roadmap. Complete guide to become a Software Architect**](https://roadmap.sh/software-architect) by Kamran Ahmed.
+
 ![Architect roadmap](./src/archRoadmap.jpg)
 
 # Types of Solution Architects


### PR DESCRIPTION
Hi @justinamiller,

I came across your repository [SoftwareArchitect](https://github.com/justinamiller/SoftwareArchitect) and found it to be a valuable resource for Software Architect enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Software Architect Roadmap"](https://roadmap.sh/software-architect). I took the initiative to submit a ["Pull Request"](https://github.com/justinamiller/SoftwareArchitect/pull/14) adding it in ["Architect's Technology Roadmap"]() section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz