### PR TITLE
feat: structured logging with sinks, levels, and CLI integration

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -2,20 +2,22 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import {
 	Agent,
-	Viewport,
+	LogLevel,
 	VercelModelAdapter,
-	type LanguageModel,
+	Viewport,
+	setGlobalLogLevel,
 	type CommandResult,
+	type LanguageModel,
 	type StepRecord,
 } from 'open-browser';
 import {
 	Spinner,
+	displayError,
+	displayHeader,
+	displayResult,
+	displaySeparator,
 	displayStep,
 	displayTotalCost,
-	displayResult,
-	displayHeader,
-	displaySeparator,
-	displayError,
 } from '../display.js';
 
 interface RunOptions {
@@ -76,6 +78,10 @@ export function registerRunCommand(program: Command): void {
 		.option('-v, --verbose', 'Show detailed step information', false)
 		.option('--no-cost', 'Hide cost tracking information')
 		.action(async (task: string, options: RunOptions) => {
+			if (options.verbose) {
+				setGlobalLogLevel(LogLevel.DEBUG);
+			}
+
 			const stepLimit = Number.parseInt(String(options.maxSteps), 10);
 
 			displayHeader(`Agent Task: ${task}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,22 +1,36 @@
 #!/usr/bin/env bun
 import { Command } from 'commander';
-import { registerOpenCommand } from './commands/open.js';
+import { LogLevel, parseLogLevel, setGlobalLogLevel } from 'open-browser';
 import { registerClickCommand } from './commands/click.js';
-import { registerTypeCommand } from './commands/type.js';
-import { registerStateCommand } from './commands/state.js';
-import { registerScreenshotCommand } from './commands/screenshot.js';
 import { registerEvalCommand } from './commands/eval.js';
 import { registerExtractCommand } from './commands/extract.js';
-import { registerSessionsCommand } from './commands/sessions.js';
-import { registerRunCommand } from './commands/run.js';
 import { registerInteractiveCommand } from './commands/interactive.js';
+import { registerOpenCommand } from './commands/open.js';
+import { registerRunCommand } from './commands/run.js';
+import { registerScreenshotCommand } from './commands/screenshot.js';
+import { registerSessionsCommand } from './commands/sessions.js';
+import { registerStateCommand } from './commands/state.js';
+import { registerTypeCommand } from './commands/type.js';
 
 const program = new Command();
 
 program
 	.name('open-browser')
 	.description('AI-powered autonomous web browsing CLI')
-	.version('0.1.0');
+	.version('0.1.0')
+	.option('--log-level <level>', 'Set log level (trace, debug, info, warn, error, silent)', 'info')
+	.hook('preAction', (thisCommand) => {
+		const level = thisCommand.opts().logLevel;
+		if (level) {
+			const parsed = parseLogLevel(level);
+			if (parsed !== undefined) {
+				setGlobalLogLevel(parsed);
+			} else {
+				console.error(`Unknown log level: ${level}. Valid: trace, debug, info, warn, error, silent`);
+				process.exit(1);
+			}
+		}
+	});
 
 // ── Browser manipulation commands ──
 registerOpenCommand(program);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,11 @@ export {
 	getGlobalLogLevel,
 	setLogColors,
 	setLogTimestamps,
+	setGlobalLogSink,
+	getGlobalLogSink,
+	parseLogLevel,
+	type LogSink,
+	type LogEntry,
 } from './logging.js';
 
 // ── Observability ──

--- a/packages/core/src/logging.ts
+++ b/packages/core/src/logging.ts
@@ -1,6 +1,23 @@
 import { LogLevel } from './types.js';
 
+// ── Types ──
+
+export interface LogSink {
+	write(entry: LogEntry): void;
+}
+
+export interface LogEntry {
+	level: LogLevel;
+	name: string;
+	message: string;
+	args: unknown[];
+	timestamp: Date;
+}
+
+// ── Constants ──
+
 const LEVEL_NAMES: Record<number, string> = {
+	[LogLevel.TRACE]: 'TRACE',
 	[LogLevel.DEBUG]: 'DEBUG',
 	[LogLevel.INFO]: 'INFO',
 	[LogLevel.WARN]: 'WARN',
@@ -8,6 +25,7 @@ const LEVEL_NAMES: Record<number, string> = {
 };
 
 const LEVEL_COLORS: Record<number, string> = {
+	[LogLevel.TRACE]: '\x1b[90m', // gray
 	[LogLevel.DEBUG]: '\x1b[36m', // cyan
 	[LogLevel.INFO]: '\x1b[32m',  // green
 	[LogLevel.WARN]: '\x1b[33m',  // yellow
@@ -18,9 +36,34 @@ const RESET = '\x1b[0m';
 const DIM = '\x1b[2m';
 const BOLD = '\x1b[1m';
 
-let globalLevel: LogLevel = LogLevel.INFO;
+const LEVEL_PARSE_MAP: Record<string, LogLevel> = {
+	trace: LogLevel.TRACE,
+	debug: LogLevel.DEBUG,
+	info: LogLevel.INFO,
+	warn: LogLevel.WARN,
+	error: LogLevel.ERROR,
+	silent: LogLevel.SILENT,
+};
+
+// ── Global state ──
+
+let globalLevel: LogLevel = resolveInitialLogLevel();
 let useColors = true;
 let logTimestamps = true;
+let globalSink: LogSink | null = null;
+
+function resolveInitialLogLevel(): LogLevel {
+	const env =
+		(typeof process !== 'undefined' && process.env?.OPEN_BROWSER_LOG_LEVEL) ||
+		(typeof process !== 'undefined' && process.env?.LOG_LEVEL);
+	if (env) {
+		const parsed = LEVEL_PARSE_MAP[env.toLowerCase()];
+		if (parsed !== undefined) return parsed;
+	}
+	return LogLevel.INFO;
+}
+
+// ── Global configuration ──
 
 export function setGlobalLogLevel(level: LogLevel): void {
 	globalLevel = level;
@@ -37,6 +80,20 @@ export function setLogColors(enabled: boolean): void {
 export function setLogTimestamps(enabled: boolean): void {
 	logTimestamps = enabled;
 }
+
+export function setGlobalLogSink(sink: LogSink | null): void {
+	globalSink = sink;
+}
+
+export function getGlobalLogSink(): LogSink | null {
+	return globalSink;
+}
+
+export function parseLogLevel(value: string): LogLevel | undefined {
+	return LEVEL_PARSE_MAP[value.toLowerCase()];
+}
+
+// ── Formatting ──
 
 function formatTimestamp(): string {
 	const now = new Date();
@@ -74,9 +131,30 @@ function formatMessage(
 	return parts.join(' ');
 }
 
+// ── Default console sink ──
+
+const consoleSink: LogSink = {
+	write(entry: LogEntry): void {
+		const formatted = formatMessage(entry.level, entry.name, entry.message);
+		switch (entry.level) {
+			case LogLevel.ERROR:
+				console.error(formatted, ...entry.args);
+				break;
+			case LogLevel.WARN:
+				console.warn(formatted, ...entry.args);
+				break;
+			default:
+				console.log(formatted, ...entry.args);
+		}
+	},
+};
+
+// ── Logger ──
+
 export class Logger {
 	readonly name: string;
 	private level: LogLevel | null = null;
+	private sink: LogSink | null = null;
 
 	constructor(name: string) {
 		this.name = name;
@@ -86,12 +164,20 @@ export class Logger {
 		this.level = level;
 	}
 
+	setSink(sink: LogSink | null): void {
+		this.sink = sink;
+	}
+
 	getEffectiveLevel(): LogLevel {
 		return this.level ?? globalLevel;
 	}
 
 	isEnabled(level: LogLevel): boolean {
 		return level >= this.getEffectiveLevel();
+	}
+
+	trace(message: string, ...args: unknown[]): void {
+		this.log(LogLevel.TRACE, message, ...args);
 	}
 
 	debug(message: string, ...args: unknown[]): void {
@@ -110,23 +196,30 @@ export class Logger {
 		this.log(LogLevel.ERROR, message, ...args);
 	}
 
+	child(childName: string): Logger {
+		const child = createLogger(`${this.name}:${childName}`);
+		if (this.level !== null) child.setLevel(this.level);
+		if (this.sink !== null) child.setSink(this.sink);
+		return child;
+	}
+
 	private log(level: LogLevel, message: string, ...args: unknown[]): void {
 		if (!this.isEnabled(level)) return;
 
-		const formatted = formatMessage(level, this.name, message);
+		const entry: LogEntry = {
+			level,
+			name: this.name,
+			message,
+			args,
+			timestamp: new Date(),
+		};
 
-		switch (level) {
-			case LogLevel.ERROR:
-				console.error(formatted, ...args);
-				break;
-			case LogLevel.WARN:
-				console.warn(formatted, ...args);
-				break;
-			default:
-				console.log(formatted, ...args);
-		}
+		const sink = this.sink ?? globalSink ?? consoleSink;
+		sink.write(entry);
 	}
 }
+
+// ── Factory ──
 
 const loggerCache = new Map<string, Logger>();
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -57,10 +57,12 @@ export type Rect = z.infer<typeof RectSchema>;
 // ── Common enums ──
 
 export const LogLevel = {
-	DEBUG: 0,
-	INFO: 1,
-	WARN: 2,
-	ERROR: 3,
+	TRACE: 0,
+	DEBUG: 1,
+	INFO: 2,
+	WARN: 3,
+	ERROR: 4,
+	SILENT: 5,
 } as const;
 export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
 

--- a/packages/core/src/viewport/event-hub.ts
+++ b/packages/core/src/viewport/event-hub.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../logging.js';
+
+const logger = createLogger('event-hub');
+
 type Handler<T = unknown> = (payload: T) => void;
 type RequestHandler<Req = unknown, Res = unknown> = (payload: Req) => Promise<Res>;
 
@@ -45,7 +49,7 @@ export class EventHub<
 				try {
 					handler(payload);
 				} catch (error) {
-					console.error(`Error in event handler for "${event}":`, error);
+					logger.error(`Error in event handler for "${event}":`, error);
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

The existing `Logger` class works but is hardcoded to `console.*` output with no way to redirect, filter granularly, or suppress logs in tests. This PR upgrades it into a proper structured logging system while staying backward-compatible with all existing `createLogger()` call sites.

### What changed

**New `LogSink` interface** — decouples log output from `console.*`. You can now redirect logs to a buffer, file, or test spy:

```typescript
import { setGlobalLogSink, type LogSink, type LogEntry } from 'open-browser';

const logs: LogEntry[] = [];
const bufferSink: LogSink = { write: (entry) => logs.push(entry) };

setGlobalLogSink(bufferSink);  // all loggers now write here
```

Individual loggers can also override the sink via `logger.setSink()`.

**New `LogEntry` type** — every log call produces a structured entry with `level`, `name`, `message`, `args`, and `timestamp`, making it easy to build custom formatters or ship logs to external systems.

**Two new log levels:**
- `TRACE` (0) — below DEBUG, for very verbose internal output
- `SILENT` (5) — above ERROR, suppresses all output (ideal for tests)

**Environment variable auto-detection** — the logger reads `OPEN_BROWSER_LOG_LEVEL` or `LOG_LEVEL` at startup:

```bash
OPEN_BROWSER_LOG_LEVEL=debug open-browser run "find the price"
```

**`parseLogLevel()`** — public utility to convert a string like `"debug"` into the corresponding `LogLevel` constant.

**Child loggers** — `logger.child(name)` creates a sub-logger (e.g. `agent:planner`) that inherits the parent's level and sink:

```typescript
const logger = createLogger('agent');
const plannerLog = logger.child('planner'); // name = "agent:planner"
```

**`EventHub` fix** — the one bare `console.error` in `event-hub.ts` now uses a proper logger.

**CLI `--log-level` flag** — new global option on the CLI:

```bash
open-browser --log-level debug run "search for cats"
open-browser --log-level silent run "quiet run"
```

**`--verbose` wired to DEBUG** — the existing `-v` flag on the `run` command now sets the core log level to `DEBUG`, so internal agent/browser logs appear alongside step output.

### Files changed

| File | Change |
|---|---|
| `core/src/types.ts` | Added `TRACE` and `SILENT` to `LogLevel` |
| `core/src/logging.ts` | `LogSink`, `LogEntry`, env var detection, `child()`, `parseLogLevel()` |
| `core/src/index.ts` | Export new types and functions |
| `core/src/viewport/event-hub.ts` | Replace `console.error` with logger |
| `cli/src/index.ts` | Global `--log-level` option with `preAction` hook |
| `cli/src/commands/run.ts` | Wire `--verbose` → `LogLevel.DEBUG` |

### Backward compatibility

- All existing `createLogger()` / `logger.info()` call sites work unchanged
- Default level remains `INFO`
- Default output still goes to `console.*` (the built-in `consoleSink`)
- The numeric values of `DEBUG`, `INFO`, `WARN`, `ERROR` changed (shifted by 1), but all code uses the named constants — no raw numbers anywhere in the codebase

## Test plan

- [x] `bun run build` — all 3 packages compile clean
- [x] `bun run test` — all 364 tests pass
- [ ] Manual: `open-browser --log-level trace run "..."` shows TRACE-level output
- [ ] Manual: `OPEN_BROWSER_LOG_LEVEL=silent bun run ...` suppresses all logs
- [ ] Manual: `open-browser run -v "..."` shows DEBUG-level agent internals