### PR TITLE
feat: npm publishing workflow and build configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish to npm
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: bun install
+
+      # Type-check
+      - run: bun run build
+
+      # Run tests
+      - run: bun run --filter 'open-browser' test
+
+      # Build JS output for publishing
+      - run: bun run --filter 'open-browser' build:publish
+      - run: bun run --filter '@open-browser/cli' build:publish
+      - run: bun run --filter '@open-browser/sandbox' build:publish
+
+      # Publish packages in dependency order
+      - name: Publish open-browser (core)
+        run: npm publish --workspace=packages/core --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @open-browser/sandbox
+        run: npm publish --workspace=packages/sandbox --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @open-browser/cli
+        run: npm publish --workspace=packages/cli --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "workspaces": ["packages/*"],
   "scripts": {
     "build": "bun run --filter '*' build",
+    "build:publish": "bun run --filter '*' build:publish",
+    "clean": "bun run --filter '*' clean",
     "test": "bun run --filter '*' test",
     "lint": "biome check .",
     "format": "biome format --write ."

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,17 +5,54 @@
   "type": "module",
   "main": "src/index.ts",
   "bin": {
-    "open-browser": "src/index.ts"
+    "open-browser": "dist/index.js"
   },
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc --noEmit",
+    "build:publish": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "prepublishOnly": "bun run clean && bun run build:publish",
     "test": "bun test",
     "start": "bun run src/index.ts"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "browser",
+    "automation",
+    "ai",
+    "cli",
+    "agent"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ntegrals/openbrowser.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/ntegrals/openbrowser#readme",
+  "bugs": {
+    "url": "https://github.com/ntegrals/openbrowser/issues"
+  },
+  "author": "ntegrals",
+  "license": "MIT",
   "dependencies": {
     "open-browser": "workspace:*",
     "commander": "^12.1.0",
     "chalk": "^5.4.0"
-  },
-  "license": "MIT"
+  }
 }

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,13 +6,48 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
+  "files": [
+    "dist",
+    "src",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc --noEmit",
+    "build:publish": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "prepublishOnly": "bun run clean && bun run build:publish",
     "test": "bun test",
     "lint": "biome check src/"
   },
+  "keywords": [
+    "browser",
+    "automation",
+    "ai",
+    "agent",
+    "web",
+    "scraping",
+    "playwright",
+    "llm"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ntegrals/openbrowser.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/ntegrals/openbrowser#readme",
+  "bugs": {
+    "url": "https://github.com/ntegrals/openbrowser/issues"
+  },
+  "author": "ntegrals",
+  "license": "MIT",
   "dependencies": {
     "ai": "^4.2.0",
     "@ai-sdk/openai": "^1.1.0",
@@ -35,6 +70,5 @@
     "sharp": {
       "optional": true
     }
-  },
-  "license": "MIT"
+  }
 }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -6,14 +6,47 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
+  "files": [
+    "dist",
+    "src",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc --noEmit",
+    "build:publish": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "prepublishOnly": "bun run clean && bun run build:publish",
     "test": "bun test"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "browser",
+    "automation",
+    "sandbox",
+    "agent"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ntegrals/openbrowser.git",
+    "directory": "packages/sandbox"
+  },
+  "homepage": "https://github.com/ntegrals/openbrowser#readme",
+  "bugs": {
+    "url": "https://github.com/ntegrals/openbrowser/issues"
+  },
+  "author": "ntegrals",
+  "license": "MIT",
   "dependencies": {
     "open-browser": "workspace:*"
-  },
-  "license": "MIT"
+  }
 }

--- a/packages/sandbox/tsconfig.build.json
+++ b/packages/sandbox/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Adds everything needed to publish the three packages (`open-browser`, `@open-browser/cli`, `@open-browser/sandbox`) to the npm registry, triggered automatically by version tags.

### What changed

**Build configuration** — new `tsconfig.build.json` per package

Each package now has a `tsconfig.build.json` that extends the base config but overrides `noEmit: false` and `allowImportingTsExtensions: false`, emitting JS + declarations + source maps to `dist/`. The existing `tsc --noEmit` type-check workflow is unchanged.

```
packages/core/tsconfig.build.json
packages/cli/tsconfig.build.json
packages/sandbox/tsconfig.build.json
```

**Package.json updates** — publishing metadata for all 3 packages

- **`exports`** with conditional resolution:
  - `bun` → `./src/index.ts` (workspace development)
  - `types` → `./src/index.ts` (TypeScript type resolution)
  - `import` → `./dist/index.js` (npm consumers)
- **`files`** — limits the published tarball to `dist/`, `src/`, `LICENSE`, `README.md`
- **`publishConfig.access: "public"`** — for scoped packages (`@open-browser/*`)
- **`repository`**, **`homepage`**, **`bugs`**, **`keywords`**, **`author`** — standard npm metadata
- **New scripts:**
  - `build:publish` — compiles to JS via `tsconfig.build.json`
  - `clean` — removes `dist/` and `*.tsbuildinfo`
  - `prepublishOnly` — runs clean + build:publish before any npm publish

**Root package.json** — added `build:publish` and `clean` aggregate scripts

**GitHub Actions workflow** — `.github/workflows/publish.yml`

```yaml
on:
  push:
    tags: ['v*']
```

Steps:
1. Checkout + setup Bun + Node.js 20
2. `bun install` + `bun run build` (type-check)
3. `bun run --filter 'open-browser' test` (run tests)
4. Build each package in dependency order (`core` → `sandbox` → `cli`)
5. Publish each package with `--provenance` for supply-chain attestation

### How to release

```bash
# Bump version in all package.json files
# Then tag and push:
git tag v1.2.0
git push origin v1.2.0
```

The workflow will build, test, and publish all three packages to npm.

### Requirements

- Add `NPM_TOKEN` as a repository secret in GitHub Settings → Secrets → Actions
- The npm token needs publish permissions for the `open-browser` and `@open-browser` scope

### Development workflow unchanged

- `bun run build` — still runs `tsc --noEmit` (type-check only)
- `bun run test` — unchanged
- Bun resolves workspace packages via the `bun` export condition → source files
- No `dist/` directory needed during development

## Test plan

- [x] `bun run clean` — removes dist and tsbuildinfo from all packages
- [x] `bun run build` — type-check passes (all 3 packages)
- [x] `bun run build:publish` — emits JS + declarations to `dist/` (all 3 packages)
- [x] `bun run test` — all 364 tests pass
- [ ] Create a test tag and verify the GitHub Actions workflow runs
- [ ] Add `NPM_TOKEN` secret and verify packages publish to npm