### PR TITLE
fix: consolidate pricing tables to single source of truth

### DIFF
--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { Command, CommandResult } from '../commands/types.js';
 import type { ViewportSnapshot, ViewportHistory } from '../viewport/types.js';
 import type { InferenceUsage } from '../model/types.js';
+import { DEFAULT_COST_RATES, type CostRates } from '../metering/types.js';
 
 // ── Agent Settings ──
 
@@ -490,41 +491,34 @@ export interface AccumulatedCost {
 	totalCost: number;
 }
 
-/** Per-model pricing in USD per 1M tokens */
-export interface PricingTable {
-	inputPer1M: number;
-	outputPer1M: number;
-}
+/**
+ * @deprecated Use `PricingTable` from `metering/types` instead.
+ * Kept as a re-export for backward compatibility.
+ */
+export type { PricingTable } from '../metering/types.js';
 
-export const PRICING_TABLE: Record<string, PricingTable> = {
-	'gpt-4o': { inputPer1M: 2.5, outputPer1M: 10 },
-	'gpt-4o-mini': { inputPer1M: 0.15, outputPer1M: 0.6 },
-	'gpt-4-turbo': { inputPer1M: 10, outputPer1M: 30 },
-	'claude-3-opus': { inputPer1M: 15, outputPer1M: 75 },
-	'claude-3-5-sonnet': { inputPer1M: 3, outputPer1M: 15 },
-	'claude-3-5-haiku': { inputPer1M: 0.8, outputPer1M: 4 },
-	'claude-3-haiku': { inputPer1M: 0.25, outputPer1M: 1.25 },
-	'gemini-2.0-flash': { inputPer1M: 0.1, outputPer1M: 0.4 },
-	'gemini-1.5-pro': { inputPer1M: 1.25, outputPer1M: 5 },
-	'gemini-1.5-flash': { inputPer1M: 0.075, outputPer1M: 0.3 },
-};
+/**
+ * @deprecated Use `DEFAULT_COST_RATES` from `metering/types` instead.
+ * Kept as a re-export for backward compatibility.
+ */
+export { DEFAULT_COST_RATES as PRICING_TABLE } from '../metering/types.js';
 
 export function calculateStepCost(
 	inputTokens: number,
 	outputTokens: number,
 	modelId: string,
 ): StepCostBreakdown | undefined {
-	let pricing: PricingTable | undefined;
-	for (const [key, value] of Object.entries(PRICING_TABLE)) {
+	let rates: CostRates | undefined;
+	for (const [key, value] of Object.entries(DEFAULT_COST_RATES)) {
 		if (modelId.startsWith(key)) {
-			pricing = value;
+			rates = value;
 			break;
 		}
 	}
-	if (!pricing) return undefined;
+	if (!rates) return undefined;
 
-	const inputCost = (inputTokens / 1_000_000) * pricing.inputPer1M;
-	const outputCost = (outputTokens / 1_000_000) * pricing.outputPer1M;
+	const inputCost = (inputTokens / 1_000_000) * rates.inputCostPerMillion;
+	const outputCost = (outputTokens / 1_000_000) * rates.outputCostPerMillion;
 	return { inputCost, outputCost, totalCost: inputCost + outputCost };
 }
 


### PR DESCRIPTION
## Summary

The codebase had **two separate pricing tables** with conflicting data:

- `PRICING_TABLE` in `agent/types.ts` — 10 models, stale pricing, used by `calculateStepCost()`
- `DEFAULT_COST_RATES` in `metering/types.ts` — 24+ models with current pricing, used by `UsageMeter`

This caused `calculateStepCost()` to return `undefined` for newer models (Claude 4, o1, o3-mini, DeepSeek, Mistral, Gemini 2.5), making agent cost reports incomplete.

### Fix

- Removed the duplicate `PRICING_TABLE` constant and `PricingTable` interface from `agent/types.ts`
- Re-exported `DEFAULT_COST_RATES` as `PRICING_TABLE` for backward compatibility
- Re-exported `PricingTable` type from metering
- Updated `calculateStepCost()` to use `DEFAULT_COST_RATES` directly

### Models now covered by cost tracking

| Provider | Models |
|---|---|
| OpenAI | gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-4.5-preview, o1, o1-mini, o1-preview, o3-mini |
| Anthropic | claude-3-5-sonnet, claude-3-5-haiku, claude-3-opus, claude-3-haiku, claude-4-sonnet, claude-4-opus |
| Google | gemini-1.5-pro, gemini-1.5-flash, gemini-2.0-flash, gemini-2.0-pro, gemini-2.5-pro, gemini-2.5-flash |
| Mistral | mistral-large, mistral-small, codestral |
| DeepSeek | deepseek-chat, deepseek-reasoner |

### Backward compatibility

- `PRICING_TABLE` is still exported (as an alias for `DEFAULT_COST_RATES`)
- `calculateStepCost()` signature unchanged
- `AgentPricingTable` type still exported from index.ts

## Test plan

- [x] `bun run build` — all 3 packages compile clean
- [x] `bun run test` — all 364 tests pass
- [x] `calculateStepCost('claude-4-sonnet', ...)` now returns a cost (previously `undefined`)