### PR TITLE
fix: break content truncation at semantic boundaries

### DIFF
--- a/packages/core/src/page/content-extractor.ts
+++ b/packages/core/src/page/content-extractor.ts
@@ -243,14 +243,31 @@ export async function extractMarkdown(
 		markdown = markdown.slice(startOffset);
 	}
 
-	// Apply max length
+	// Apply max length, breaking at the nearest semantic boundary
 	let truncated = false;
 	if (options?.maxLength && markdown.length > options.maxLength) {
-		markdown = markdown.slice(0, options.maxLength);
-		// Try to break at a paragraph boundary
-		const lastParagraph = markdown.lastIndexOf('\n\n');
-		if (lastParagraph > markdown.length * 0.8) {
+		const limit = options.maxLength;
+		const minKeep = Math.floor(limit * 0.5);
+		const region = markdown.slice(0, limit);
+
+		// Try paragraph boundary first, then sentence, then word
+		const lastParagraph = region.lastIndexOf('\n\n');
+		const lastSentence = Math.max(
+			region.lastIndexOf('. '),
+			region.lastIndexOf('.\n'),
+			region.lastIndexOf('? '),
+			region.lastIndexOf('! '),
+		);
+		const lastWord = region.lastIndexOf(' ');
+
+		if (lastParagraph > minKeep) {
 			markdown = markdown.slice(0, lastParagraph);
+		} else if (lastSentence > minKeep) {
+			markdown = markdown.slice(0, lastSentence + 1);
+		} else if (lastWord > minKeep) {
+			markdown = markdown.slice(0, lastWord);
+		} else {
+			markdown = region;
 		}
 		truncated = true;
 	}


### PR DESCRIPTION
## Summary

When `extractMarkdown()` exceeds `maxLength`, the previous logic only broke at a paragraph boundary if it was in the last 20% of content. Otherwise it sliced mid-word/sentence, producing broken markdown.

### Before

```
# Some Article

This is a long paragraph about...  ← sliced here mid-sentence

[... content truncated, ~500 chars remaining]
```

### After

The truncation now tries boundaries in priority order:

1. **Paragraph break** (`\n\n`) — cleanest cut
2. **Sentence ending** (`. `, `.\n`, `? `, `! `) — preserves complete thoughts
3. **Word boundary** (space) — avoids mid-word cuts
4. **Hard limit** — only if no boundary found in the first 50%

All boundaries must be at least 50% into the content to avoid over-truncation.

### Code change

`packages/core/src/page/content-extractor.ts` lines 247-268

## Test plan

- [x] `bun run build` — compiles clean
- [x] `bun run test` — all 364 tests pass