### PR TITLE
feat: auto-cleanup visual tracer overlays on page navigation

### DIFF
--- a/packages/core/src/viewport/visual-tracer.ts
+++ b/packages/core/src/viewport/visual-tracer.ts
@@ -978,4 +978,19 @@ export class VisualTracer {
 			{ attr: OVERLAY_ATTR },
 		);
 	}
+
+	/**
+	 * Attaches automatic overlay cleanup on page navigation.
+	 * Call once per page to ensure overlays don't persist across navigations.
+	 * Returns a cleanup function to detach the listener.
+	 */
+	attachAutoCleanup(page: Page): () => void {
+		const handler = () => {
+			this.clearOverlays(page).catch(() => {});
+		};
+		page.on('framenavigated', handler);
+		return () => {
+			page.off('framenavigated', handler);
+		};
+	}
 }


### PR DESCRIPTION
## Summary

Visual tracer overlays (click highlights, scroll indicators, etc.) persist across page navigations because they're removed by timeouts that get cancelled when the page unloads. This leaves stale overlay elements or causes visual artifacts on the new page.

### Fix

Added `attachAutoCleanup(page)` method that listens to `framenavigated` events and automatically calls `clearOverlays()`:

```typescript
const tracer = new VisualTracer();
const detach = tracer.attachAutoCleanup(page);

// Overlays now auto-clear on navigation
await tracer.highlightElement(page, '#btn', 'Click');
await page.click('#btn'); // navigates → overlays cleaned up

// Detach when done
detach();
```

Returns a cleanup function to remove the listener when the tracer is no longer needed.

## Test plan

- [x] `bun run build` — compiles clean
- [x] `bun run test` — all 364 tests pass