### PR TITLE
fix: track conversation compaction LLM costs

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -117,6 +117,9 @@ export class Agent {
 			includeLastScreenshot: this.settings.enableScreenshots,
 			maskedValues: this.settings.maskedValues,
 			compaction: this.settings.conversationCompaction,
+			onCompactionUsage: (usage) => {
+				this.updateCostTracking(usage.inputTokens, usage.outputTokens, this.state.step);
+			},
 		});
 
 		this.loopDetector = new StallDetector();

--- a/packages/core/src/agent/conversation/service.ts
+++ b/packages/core/src/agent/conversation/service.ts
@@ -349,6 +349,11 @@ export class ConversationManager {
 				temperature: 0,
 			});
 
+			// Report compaction cost to caller
+			if (this.options.onCompactionUsage && completion.usage) {
+				this.options.onCompactionUsage(completion.usage);
+			}
+
 			const summaryText = `[Conversation summary of steps 1-${toSummarize[toSummarize.length - 1]?.step ?? '?'}]\n${completion.parsed.summary}`;
 
 			// Replace the summarized messages with a single summary

--- a/packages/core/src/agent/conversation/types.ts
+++ b/packages/core/src/agent/conversation/types.ts
@@ -1,4 +1,5 @@
 import type { Message } from '../../model/messages.js';
+import type { InferenceUsage } from '../../model/types.js';
 import type { CompactionPolicy } from '../types.js';
 import type { LanguageModel } from '../../model/interface.js';
 
@@ -14,6 +15,8 @@ export interface ConversationManagerOptions {
 	compaction?: CompactionPolicy;
 	/** LanguageModel used for LLM-based compaction. Ignored if compaction is not set. */
 	compactionModel?: LanguageModel;
+	/** Called with token usage after each LLM compaction call, for cost tracking. */
+	onCompactionUsage?: (usage: InferenceUsage) => void;
 }
 
 // ── Managed Message ──


### PR DESCRIPTION
## Summary

When conversation compaction runs (`compactWithLlm()`), it calls an LLM to summarize older messages. These tokens were never reported to the agent's cost tracker, making cost reports incomplete for long-running agents with compaction enabled.

### Fix

- Added `onCompactionUsage` callback to `ConversationManagerOptions`
- `compactWithLlm()` now calls the callback with `InferenceUsage` after each compaction LLM call
- `Agent` wires this callback to its `updateCostTracking()` method

### Impact

Agents with `conversationCompaction` enabled will now include compaction costs in `result.totalCost`. No change for agents without compaction.

## Test plan

- [x] `bun run build` — all 3 packages compile clean
- [x] `bun run test` — all 364 tests pass
- [x] Callback is optional — existing ConversationManager usages unaffected