### PR TITLE
fix: update Chrome launch flags for modern browsers

### DIFF
--- a/packages/core/src/viewport/launch-profile.ts
+++ b/packages/core/src/viewport/launch-profile.ts
@@ -31,6 +31,9 @@ export const CHROME_AUTOMATION_FLAGS = [
 	'--disable-infobars',
 	'--disable-session-crashed-bubble',
 	'--force-color-profile=srgb',
+	// Modern Chrome flags (112+)
+	'--disable-search-engine-choice-screen',
+	'--hide-crash-restore-bubble',
 ];
 
 /**
@@ -40,33 +43,34 @@ export const CHROME_AUTOMATION_FLAGS = [
 export const CHROME_STRIPPED_FEATURES = [
 	'InterestFeedContentSuggestions',
 	'Translate',
+	'TranslateUI',
 	'OptimizationHints',
 	'MediaRouter',
 	'DialMediaRouteProvider',
 	'CalculatorTool',
-	'CrashedTabFinder',
 	'AutofillServerCommunication',
 	'BackgroundTracing',
 	'NtpTiles',
-	'OneGoogleBar',
-	'ReadLater',
 	'NTPArticleSuggestions',
+	'NTPSigninPromo',
 	'CrossDeviceSync',
 	'PrivacySandboxSettings4',
+	'PrivacySandboxPromptV2',
 	'SidePanelPinning',
 	'HistoryEmbeddings',
-	'PrivacySandboxPromptV2',
 	'GlobalMediaControls',
 	'ComposeService',
 	'AutofillFeature',
-	'NTPSigninPromo',
 	'Prerender2',
 	'TabGroupsSave',
+	'SearchEngineChoice',
+	'InfoBarDisplay',
 ];
 
 export const ANTI_DETECTION_FLAGS = [
 	'--disable-blink-features=AutomationControlled',
 	'--disable-features=AutomationControlled',
+	'--disable-automation-extension',
 ];
 
 export const CONTAINER_FLAGS = [


### PR DESCRIPTION
## Summary

Updates the browser launch profile flags for Chrome 112+ compatibility, adding flags to suppress new UI elements that interfere with automation and improving bot detection evasion.

### Changes

**CHROME_AUTOMATION_FLAGS** — new flags:
- `--disable-search-engine-choice-screen` — suppresses EU compliance search engine picker
- `--hide-crash-restore-bubble` — prevents "Restore session?" dialog in headless

**CHROME_STRIPPED_FEATURES** — updated:
- Added: `TranslateUI`, `SearchEngineChoice`, `InfoBarDisplay`
- Removed obsolete: `OneGoogleBar`, `ReadLater`, `CrashedTabFinder` (no longer recognized by modern Chrome)

**ANTI_DETECTION_FLAGS** — added:
- `--disable-automation-extension` — prevents detection via Chrome automation extension

## Test plan

- [x] `bun run build` — compiles clean
- [x] `bun run test` — all 364 tests pass (including launch profile tests)