### PR TITLE
fix: include external memory in sandbox OOM detection

### DIFF
--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -34,6 +34,7 @@ class ResourceMonitor {
 	private intervalId: ReturnType<typeof setInterval> | null = null;
 	private snapshots: ResourceSnapshot[] = [];
 	private peakMemoryMB = 0;
+	private peakExternalMB = 0;
 	private startCpuUsage: NodeJS.CpuUsage | null = null;
 	private readonly limitMB: number;
 	private onOOM: (() => void) | null = null;
@@ -87,15 +88,24 @@ class ResourceMonitor {
 		if (rssMB > this.peakMemoryMB) {
 			this.peakMemoryMB = rssMB;
 		}
+		if (externalMB > this.peakExternalMB) {
+			this.peakExternalMB = externalMB;
+		}
 
-		// Check OOM condition against RSS (total process memory)
-		if (rssMB > this.limitMB && this.onOOM) {
+		// Check OOM condition against RSS + external memory (native buffers,
+		// graphics allocations, etc. that grow outside the V8 heap)
+		const totalMemoryMB = rssMB + externalMB;
+		if (totalMemoryMB > this.limitMB && this.onOOM) {
 			this.onOOM();
 		}
 	}
 
 	getPeakMemoryMB(): number {
 		return Math.round(this.peakMemoryMB * 100) / 100;
+	}
+
+	getPeakExternalMB(): number {
+		return Math.round(this.peakExternalMB * 100) / 100;
 	}
 
 	getCpuTimeMs(): number {
@@ -451,6 +461,7 @@ export class Sandbox {
 		return {
 			durationMs: Date.now() - startTime,
 			peakMemoryMB: monitor.getPeakMemoryMB(),
+			peakExternalMB: monitor.getPeakExternalMB(),
 			stepsExecuted,
 			pagesVisited: visitedUrls.size,
 			visitedUrls: [...visitedUrls],

--- a/packages/sandbox/src/types.ts
+++ b/packages/sandbox/src/types.ts
@@ -52,8 +52,10 @@ export interface CapturedOutput {
 export interface SandboxMetrics {
 	/** Total execution time in milliseconds */
 	durationMs: number;
-	/** Peak memory usage in MB */
+	/** Peak RSS memory usage in MB */
 	peakMemoryMB: number;
+	/** Peak external (native/buffer) memory usage in MB */
+	peakExternalMB: number;
 	/** Number of agent steps executed */
 	stepsExecuted: number;
 	/** Number of unique pages visited */


### PR DESCRIPTION
## Summary

The sandbox's OOM detection only checked RSS memory, missing external memory (native addon allocations, Buffers, graphics memory from Playwright/Chromium). For long-running agents, external memory can grow unbounded without triggering OOM — the process gets killed by the OS instead of gracefully shutting down.

### Changes

**OOM detection** — now checks `RSS + external` against the limit instead of RSS alone. This catches memory growth from:
- Playwright's CDP protocol buffers
- Screenshot data (sharp image processing)
- Chromium's internal allocations exposed via `process.memoryUsage().external`

**New metric** — `peakExternalMB` added to `SandboxMetrics` so callers can see the native memory breakdown:

```typescript
const result = await sandbox.run({ task, model });
console.log(result.metrics.peakMemoryMB);    // RSS peak
console.log(result.metrics.peakExternalMB);  // External/native peak
```

### Files changed

| File | Change |
|---|---|
| `sandbox/src/sandbox.ts` | Track `peakExternalMB`, check `rss + external` for OOM |
| `sandbox/src/types.ts` | Add `peakExternalMB` to `SandboxMetrics` |

## Test plan

- [x] `bun run build` — all 3 packages compile clean
- [x] `bun run test` — all 364 tests pass